### PR TITLE
Add top-level reporting helpers and attribute setting helper

### DIFF
--- a/context.go
+++ b/context.go
@@ -31,3 +31,10 @@ func From(ctx context.Context) Reporter {
 		Logger: slog.New(noopHandler{}),
 	}
 }
+
+// Set is a helper function that updates the [log/slog.Logger] on the
+// [Reporter] in the passed [context.Context] to have the passed key value
+// attributes associated with it.
+func Set(ctx context.Context, args ...any) context.Context {
+	return In(ctx, Reporter{Logger: From(ctx).Logger.With(args...)})
+}


### PR DESCRIPTION
It's really annoying at the top level, when there's no caller to bubble an error up to, to explicitly ignore the error. Instead, let's add helper methods that don't return the error.

Also, add a yikes.Set helper function that sets some arguments on the Logger in the context, and returns a new context containing the new Logger.