### PR TITLE
Add support for stacktraces

### DIFF
--- a/critical.go
+++ b/critical.go
@@ -14,3 +14,19 @@ const (
 	// require manual intervention from an operator.
 	LevelCritical slog.Level = 16
 )
+
+// ReplaceAttrLevelCritical returns a ReplaceAttr function that can be used to
+// replace the Critical level that yikes supports with the label provided, so
+// it doesn't show up as err+8 in logs.
+func ReplaceAttrLevelCritical(label string) func(groups []string, attr slog.Attr) slog.Attr {
+	return func(groups []string, attr slog.Attr) slog.Attr {
+		if attr.Key != slog.LevelKey {
+			return attr
+		}
+		level := attr.Value.Any().(slog.Level)
+		if level == LevelCritical {
+			attr.Value = slog.StringValue(label)
+		}
+		return attr
+	}
+}

--- a/report.go
+++ b/report.go
@@ -13,8 +13,29 @@ type Reporter struct {
 	//
 	// If you plan to use [Reporter.Critical], the Logger should already be
 	// configured to map the string value of [LevelCritical], or it'll show
-	// up as "ERROR+8".
+	// up as "ERROR+8". You can use [ReplaceAttrLevelCritical] to achieve
+	// this.
 	Logger *slog.Logger
+
+	// DisableStacktraces, if set to true, stops stacktraces from being
+	// generated and added as values to the error reports.
+	DisableStacktraces bool
+}
+
+func (reporter Reporter) report(ctx context.Context, level slog.Level, message string, err error, args ...any) error { //nolint:revive // we're largely just copying slog.Log at this point, this is as succinct as it gets
+	if AlreadyReported(err, level) {
+		return err
+	}
+	builtinArgs := []any{"error", err}
+	if !reporter.DisableStacktraces {
+		builtinArgs = append(builtinArgs, "stacktrace", getStacktrace())
+	}
+	args = append(builtinArgs, args...)
+	reporter.Logger.Log(ctx, level, message, args...)
+	return reportedError{
+		level: level,
+		error: err,
+	}
 }
 
 // Report calls [log/slog.Logger.Log] on the [log/slog.Logger] associated with
@@ -26,30 +47,34 @@ type Reporter struct {
 // passed into Report, Report returns the [error] as it was passed in and takes
 // no further actions.
 func (reporter Reporter) Report(ctx context.Context, level slog.Level, message string, err error, args ...any) error { //nolint:revive // we're largely just copying slog.Log at this point, this is as succinct as it gets
-	if AlreadyReported(err, level) {
-		return err
-	}
-	args = append([]any{"error", err}, args...)
-	reporter.Logger.Log(ctx, level, message, args...)
-	return reportedError{
-		level: level,
-		error: err,
-	}
+	return reporter.report(ctx, level, message, err, args...)
 }
 
 // Error calls [Reporter.Report] using the [log/slog.LevelError] level.
 func (reporter Reporter) Error(ctx context.Context, message string, err error, args ...any) error {
-	return reporter.Report(ctx, slog.LevelError, message, err, args...)
+	return reporter.report(ctx, slog.LevelError, message, err, args...)
 }
 
 // Warn calls [Reporter.Report] using the [log/slog.LevelWarn] level.
 func (reporter Reporter) Warn(ctx context.Context, message string, err error, args ...any) error {
-	return reporter.Report(ctx, slog.LevelWarn, message, err, args...)
+	return reporter.report(ctx, slog.LevelWarn, message, err, args...)
 }
 
 // Critical calls [Reporter.Report] using the [LevelCritical] level.
 func (reporter Reporter) Critical(ctx context.Context, message string, err error, args ...any) error {
-	return reporter.Report(ctx, LevelCritical, message, err, args...)
+	return reporter.report(ctx, LevelCritical, message, err, args...)
+}
+
+func (reporter Reporter) topLevelReport(ctx context.Context, level slog.Level, message string, err error, args ...any) { //nolint:revive // we're largely just copying slog.Log at this point, this is as succinct as it gets
+	if AlreadyReported(err, level) {
+		return
+	}
+	builtinArgs := []any{"error", err}
+	if !reporter.DisableStacktraces {
+		builtinArgs = append(builtinArgs, "stacktrace", getStacktrace())
+	}
+	args = append(builtinArgs, args...)
+	reporter.Logger.Log(ctx, level, message, args...)
 }
 
 // TopLevelReport calls [log/slog.Logger.Log] on the [log/slog.Logger] associated with
@@ -59,24 +84,20 @@ func (reporter Reporter) Critical(ctx context.Context, message string, err error
 // If [AlreadyReported] returns true for the [error] and [log/slog.Level]
 // passed into TopLevelReport, TopLevelReport is a no-op.
 func (reporter Reporter) TopLevelReport(ctx context.Context, level slog.Level, message string, err error, args ...any) { //nolint:revive // we're largely just copying slog.Log at this point, this is as succinct as it gets
-	if AlreadyReported(err, level) {
-		return
-	}
-	args = append([]any{"error", err}, args...)
-	reporter.Logger.Log(ctx, level, message, args...)
+	reporter.topLevelReport(ctx, level, message, err, args...)
 }
 
 // TopLevelError calls [Reporter.TopLevelReport] using the [log/slog.LevelError] level.
 func (reporter Reporter) TopLevelError(ctx context.Context, message string, err error, args ...any) {
-	reporter.TopLevelReport(ctx, slog.LevelError, message, err, args...)
+	reporter.topLevelReport(ctx, slog.LevelError, message, err, args...)
 }
 
 // TopLevelWarn calls [Reporter.TopLevelReport] using the [log/slog.LevelWarn] level.
 func (reporter Reporter) TopLevelWarn(ctx context.Context, message string, err error, args ...any) {
-	reporter.TopLevelReport(ctx, slog.LevelWarn, message, err, args...)
+	reporter.topLevelReport(ctx, slog.LevelWarn, message, err, args...)
 }
 
 // TopLevelCritical calls [Reporter.TopLevelReport] using the [LevelCritical] level.
 func (reporter Reporter) TopLevelCritical(ctx context.Context, message string, err error, args ...any) {
-	reporter.TopLevelReport(ctx, LevelCritical, message, err, args...)
+	reporter.topLevelReport(ctx, LevelCritical, message, err, args...)
 }

--- a/report.go
+++ b/report.go
@@ -28,7 +28,7 @@ func (reporter Reporter) report(ctx context.Context, level slog.Level, message s
 	}
 	builtinArgs := []any{"error", err}
 	if !reporter.DisableStacktraces {
-		builtinArgs = append(builtinArgs, "stacktrace", getStacktrace())
+		builtinArgs = append(builtinArgs, getStacktrace())
 	}
 	args = append(builtinArgs, args...)
 	reporter.Logger.Log(ctx, level, message, args...)
@@ -71,7 +71,7 @@ func (reporter Reporter) topLevelReport(ctx context.Context, level slog.Level, m
 	}
 	builtinArgs := []any{"error", err}
 	if !reporter.DisableStacktraces {
-		builtinArgs = append(builtinArgs, "stacktrace", getStacktrace())
+		builtinArgs = append(builtinArgs, getStacktrace())
 	}
 	args = append(builtinArgs, args...)
 	reporter.Logger.Log(ctx, level, message, args...)

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -1,0 +1,37 @@
+package yikes
+
+import (
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+func getStacktrace() string {
+	buf := make([]uintptr, 1024)
+	// 0 is runtime.Callers, 1 is getStacktrace, 2 is either report or
+	// topLevelReport, 3 is the exported function of yikes that was called,
+	// 4 is the caller.
+	offset := 4
+	var numFrames int
+	for {
+		numFrames = runtime.Callers(offset, buf)
+		if numFrames < len(buf) {
+			break
+		}
+		buf = make([]uintptr, len(buf)*2)
+	}
+
+	frames := runtime.CallersFrames(buf[:numFrames])
+
+	var out strings.Builder
+	for frame, more := frames.Next(); more; frame, more = frames.Next() {
+		out.WriteString(frame.Function)
+		out.WriteString("\n\t")
+		out.WriteString(frame.File)
+		out.WriteString(":")
+		out.WriteString(strconv.FormatInt(int64(frame.Line), 10))
+		out.WriteString("\n")
+	}
+
+	return strings.TrimSuffix(out.String(), "\n")
+}

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -31,6 +31,7 @@ func getStacktrace() slog.Attr {
 			slog.String("file", frame.File),
 			slog.Int("line", frame.Line),
 		))
+		index++
 	}
 
 	return slog.Any("stacktrace", slog.GroupValue(result...))

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -1,12 +1,12 @@
 package yikes
 
 import (
+	"log/slog"
 	"runtime"
 	"strconv"
-	"strings"
 )
 
-func getStacktrace() string {
+func getStacktrace() slog.Attr {
 	buf := make([]uintptr, 1024)
 	// 0 is runtime.Callers, 1 is getStacktrace, 2 is either report or
 	// topLevelReport, 3 is the exported function of yikes that was called,
@@ -23,15 +23,15 @@ func getStacktrace() string {
 
 	frames := runtime.CallersFrames(buf[:numFrames])
 
-	var out strings.Builder
+	var result []slog.Attr
+	var index int
 	for frame, more := frames.Next(); more; frame, more = frames.Next() {
-		out.WriteString(frame.Function)
-		out.WriteString("\n\t")
-		out.WriteString(frame.File)
-		out.WriteString(":")
-		out.WriteString(strconv.FormatInt(int64(frame.Line), 10))
-		out.WriteString("\n")
+		result = append(result, slog.Group(strconv.Itoa(index),
+			slog.String("function", frame.Function),
+			slog.String("file", frame.File),
+			slog.Int("line", frame.Line),
+		))
 	}
 
-	return strings.TrimSuffix(out.String(), "\n")
+	return slog.Any("stacktrace", slog.GroupValue(result...))
 }


### PR DESCRIPTION
Add stacktraces to all reports, by default.

Also, implement a helper to replace the critical level provided by yikes with a specified label.